### PR TITLE
Change model plural name from "Online user activitys" to "Online user activities"

### DIFF
--- a/online_users/models.py
+++ b/online_users/models.py
@@ -9,6 +9,10 @@ class OnlineUserActivity(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     last_activity = models.DateTimeField()
 
+    class Meta:
+        verbose_name = 'Online user activity'
+        verbose_name_plural = 'Online user activities'
+
     @staticmethod
     def update_user_activity(user):
         """Updates the timestamp a user has for their last action. Uses UTC time."""


### PR DESCRIPTION
Hi @lawrencemq,

Thank you for making this package. Currently the model plural name is not set so Django will auto set it to "Online user activitys". Here is a small patch to make sure that the model is displayed correctly (to "Online user activities"). I hope you find it helpful.

Thanks again & have a nice day